### PR TITLE
Add Phase 3: Basecamp view

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -283,11 +283,11 @@ apres-ski/
 
 **Dependencies:** Phase 1 (project scaffolding must exist).
 
-- [ ] **2.1** Root layout (`app/layout.tsx`)
+- [x] **2.1** Root layout (`app/layout.tsx`)
   - Inter font via `next/font/google`
   - Metadata: title "Apres-Ski", description, OG tags
   - Wrap children in `<UserProvider>`
-- [ ] **2.2** User identity system
+- [x] **2.2** User identity system
   - `components/providers/UserProvider.tsx` (client component)
     - Reads `localStorage('apres-ski-user')` on mount
     - Exposes `{ user, isReady, needsSetup, saveUser }` via React context
@@ -295,14 +295,14 @@ apres-ski/
     - When `needsSetup` is true, renders `<UserSetupModal>`
   - `components/UserSetupModal.tsx`
     - Name input, color picker grid (10 predefined alpine colors), auto-generated avatar (initials), "Join Trip" button
-- [ ] **2.3** Responsive navigation shell
+- [x] **2.3** Responsive navigation shell
   - `components/layout/AppShell.tsx` -- desktop: `<DesktopHeader>`, mobile: `<MobileTabBar>`
   - `components/layout/DesktopHeader.tsx` -- top bar with logo + 4 nav links (md+)
   - `components/layout/MobileTabBar.tsx` -- fixed bottom bar with 4 icon+label tabs (<md)
   - Tabs: Hub `/`, Rostrum `/rostrum`, Feasts `/feasts`, Basecamp `/basecamp`
   - Content area: `pb-20 md:pb-0` for mobile tab clearance
   - Icons: inline SVGs (Home/Mountain, Bed/Calendar, Utensils, MapPin)
-- [ ] **2.4** Base UI components (`components/ui/`)
+- [x] **2.4** Base UI components (`components/ui/`)
   - `Card.tsx` -- `bg-glacier rounded-2xl shadow-sm p-5`
   - `Button.tsx` -- primary (`bg-alpine`), secondary (outline), pill-shaped
   - `Modal.tsx` -- bottom sheet on mobile, centered on desktop
@@ -320,14 +320,14 @@ apres-ski/
 
 **Dependencies:** Phase 2 (shell and user identity).
 
-- [ ] **3.1** Data hook: `lib/hooks/useBasecamp.ts`
+- [x] **3.1** Data hook: `lib/hooks/useBasecamp.ts`
   - `onSnapshot` listener on `doc(db, 'basecamp', 'current')`
   - Returns `{ basecamp, loading, error }`
-- [ ] **3.2** Write actions: `lib/actions/basecamp.ts`
+- [x] **3.2** Write actions: `lib/actions/basecamp.ts`
   - `updateBasecamp(fields)` -> `setDoc` with merge
-- [ ] **3.3** Page: `app/basecamp/page.tsx`
+- [x] **3.3** Page: `app/basecamp/page.tsx`
   - Wraps components, passes data from `useBasecamp`
-- [ ] **3.4** Components
+- [x] **3.4** Components
   - `components/basecamp/MapEmbed.tsx` -- Google Maps static iframe with coordinates
   - `components/basecamp/AddressBlock.tsx` -- address text + `CopyButton`
   - `components/basecamp/EssentialsGrid.tsx` -- 2-column grid:

--- a/app/basecamp/page.tsx
+++ b/app/basecamp/page.tsx
@@ -1,14 +1,80 @@
+"use client";
+
+import { useState } from "react";
 import { Card } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+import { useBasecamp } from "@/lib/hooks/useBasecamp";
+import { MapEmbed } from "@/components/basecamp/MapEmbed";
+import { AddressBlock } from "@/components/basecamp/AddressBlock";
+import { EssentialsGrid } from "@/components/basecamp/EssentialsGrid";
+import { EditBasecampModal } from "@/components/basecamp/EditBasecampModal";
 
 export default function BasecampPage() {
+  const { basecamp, loading } = useBasecamp();
+  const [editOpen, setEditOpen] = useState(false);
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold text-midnight">Basecamp</h1>
+        <Card className="animate-pulse h-48"><span /></Card>
+      </div>
+    );
+  }
+
+  if (!basecamp) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold text-midnight">Basecamp</h1>
+        <Card>
+          <div className="text-center py-8 space-y-3">
+            <p className="text-mist">No chalet info yet</p>
+            <Button onClick={() => setEditOpen(true)}>Set Up Basecamp</Button>
+          </div>
+        </Card>
+        <EditBasecampModal
+          isOpen={editOpen}
+          onClose={() => setEditOpen(false)}
+          basecamp={null}
+        />
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-4">
-      <h1 className="text-2xl font-bold text-midnight">Basecamp</h1>
-      <Card>
-        <p className="text-mist">
-          Chalet info, WiFi, and emergency contacts will appear here.
-        </p>
-      </Card>
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-midnight">Basecamp</h1>
+        <Button variant="secondary" onClick={() => setEditOpen(true)}>
+          Edit
+        </Button>
+      </div>
+
+      <MapEmbed coordinates={basecamp.coordinates} mapsUrl={basecamp.mapsUrl} />
+
+      {basecamp.address && (
+        <Card>
+          <h2 className="text-sm font-semibold text-midnight mb-2">Address</h2>
+          <AddressBlock address={basecamp.address} />
+        </Card>
+      )}
+
+      <EssentialsGrid basecamp={basecamp} />
+
+      {basecamp.notes && (
+        <Card>
+          <h2 className="text-sm font-semibold text-midnight mb-2">Notes</h2>
+          <p className="text-sm text-midnight/80 whitespace-pre-line">
+            {basecamp.notes}
+          </p>
+        </Card>
+      )}
+
+      <EditBasecampModal
+        isOpen={editOpen}
+        onClose={() => setEditOpen(false)}
+        basecamp={basecamp}
+      />
     </div>
   );
 }

--- a/components/basecamp/AddressBlock.tsx
+++ b/components/basecamp/AddressBlock.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { CopyButton } from "@/components/ui/CopyButton";
+
+export function AddressBlock({ address }: { address?: string }) {
+  if (!address) return null;
+
+  return (
+    <div className="flex items-start justify-between gap-2">
+      <p className="text-midnight/80 text-sm whitespace-pre-line">{address}</p>
+      <CopyButton text={address} className="shrink-0" />
+    </div>
+  );
+}

--- a/components/basecamp/EditBasecampModal.tsx
+++ b/components/basecamp/EditBasecampModal.tsx
@@ -1,0 +1,394 @@
+"use client";
+
+import { useState } from "react";
+import { Modal } from "@/components/ui/Modal";
+import { Button } from "@/components/ui/Button";
+import { useUser } from "@/components/providers/UserProvider";
+import { updateBasecamp } from "@/lib/actions/basecamp";
+import type { Basecamp } from "@/lib/types";
+
+interface FormState {
+  address: string;
+  coordinatesText: string;
+  mapsUrl: string;
+  wifiNetwork: string;
+  wifiPassword: string;
+  checkIn: string;
+  checkOut: string;
+  accessCodes: { label: string; code: string }[];
+  emergencyContacts: { name: string; phone: string; role: string }[];
+  notes: string;
+}
+
+function basecampToForm(b: Basecamp | null): FormState {
+  if (!b) {
+    return {
+      address: "",
+      coordinatesText: "",
+      mapsUrl: "",
+      wifiNetwork: "",
+      wifiPassword: "",
+      checkIn: "",
+      checkOut: "",
+      accessCodes: [],
+      emergencyContacts: [],
+      notes: "",
+    };
+  }
+  return {
+    address: b.address || "",
+    coordinatesText:
+      b.coordinates?.lat && b.coordinates?.lng
+        ? `${b.coordinates.lat}, ${b.coordinates.lng}`
+        : "",
+    mapsUrl: b.mapsUrl || "",
+    wifiNetwork: b.wifi?.network || "",
+    wifiPassword: b.wifi?.password || "",
+    checkIn: b.checkIn || "",
+    checkOut: b.checkOut || "",
+    accessCodes: b.accessCodes?.length ? [...b.accessCodes] : [],
+    emergencyContacts: b.emergencyContacts?.length
+      ? [...b.emergencyContacts]
+      : [],
+    notes: b.notes || "",
+  };
+}
+
+function parseCoordinates(
+  text: string,
+): { lat: number; lng: number } | null {
+  const parts = text.split(",").map((s) => s.trim());
+  if (parts.length !== 2) return null;
+  const lat = parseFloat(parts[0]);
+  const lng = parseFloat(parts[1]);
+  if (isNaN(lat) || isNaN(lng)) return null;
+  return { lat, lng };
+}
+
+const inputClass =
+  "w-full rounded-xl border border-mist/30 bg-powder px-4 py-2.5 text-midnight placeholder:text-mist focus:outline-none focus:ring-2 focus:ring-alpine/50";
+
+export function EditBasecampModal({
+  isOpen,
+  onClose,
+  basecamp,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  basecamp: Basecamp | null;
+}) {
+  const { user } = useUser();
+  const [form, setForm] = useState<FormState>(() => basecampToForm(basecamp));
+  const [saving, setSaving] = useState(false);
+
+  function update<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  }
+
+  function addAccessCode() {
+    setForm((prev) => ({
+      ...prev,
+      accessCodes: [...prev.accessCodes, { label: "", code: "" }],
+    }));
+  }
+
+  function removeAccessCode(index: number) {
+    setForm((prev) => ({
+      ...prev,
+      accessCodes: prev.accessCodes.filter((_, i) => i !== index),
+    }));
+  }
+
+  function updateAccessCode(
+    index: number,
+    field: "label" | "code",
+    value: string,
+  ) {
+    setForm((prev) => ({
+      ...prev,
+      accessCodes: prev.accessCodes.map((c, i) =>
+        i === index ? { ...c, [field]: value } : c,
+      ),
+    }));
+  }
+
+  function addContact() {
+    setForm((prev) => ({
+      ...prev,
+      emergencyContacts: [
+        ...prev.emergencyContacts,
+        { name: "", phone: "", role: "" },
+      ],
+    }));
+  }
+
+  function removeContact(index: number) {
+    setForm((prev) => ({
+      ...prev,
+      emergencyContacts: prev.emergencyContacts.filter((_, i) => i !== index),
+    }));
+  }
+
+  function updateContact(
+    index: number,
+    field: "name" | "phone" | "role",
+    value: string,
+  ) {
+    setForm((prev) => ({
+      ...prev,
+      emergencyContacts: prev.emergencyContacts.map((c, i) =>
+        i === index ? { ...c, [field]: value } : c,
+      ),
+    }));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!user) return;
+
+    setSaving(true);
+    try {
+      const coords = parseCoordinates(form.coordinatesText);
+      await updateBasecamp(
+        {
+          address: form.address,
+          coordinates: coords ?? { lat: 0, lng: 0 },
+          mapsUrl: form.mapsUrl,
+          wifi: { network: form.wifiNetwork, password: form.wifiPassword },
+          checkIn: form.checkIn,
+          checkOut: form.checkOut,
+          accessCodes: form.accessCodes.filter((c) => c.label || c.code),
+          emergencyContacts: form.emergencyContacts.filter(
+            (c) => c.name || c.phone,
+          ),
+          notes: form.notes,
+        },
+        user.name,
+      );
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Edit Basecamp">
+      <form onSubmit={handleSubmit} className="space-y-5">
+        {/* Address */}
+        <Field label="Address">
+          <textarea
+            value={form.address}
+            onChange={(e) => update("address", e.target.value)}
+            placeholder="123 Mountain Rd, Verbier"
+            className={inputClass}
+            rows={2}
+          />
+        </Field>
+
+        {/* Coordinates */}
+        <Field label="Coordinates" hint="lat, lng (e.g. 46.096, 7.228)">
+          <input
+            type="text"
+            value={form.coordinatesText}
+            onChange={(e) => update("coordinatesText", e.target.value)}
+            placeholder="46.096, 7.228"
+            className={inputClass}
+          />
+        </Field>
+
+        {/* Maps URL */}
+        <Field label="Maps URL">
+          <input
+            type="url"
+            value={form.mapsUrl}
+            onChange={(e) => update("mapsUrl", e.target.value)}
+            placeholder="https://maps.app.goo.gl/..."
+            className={inputClass}
+          />
+        </Field>
+
+        {/* WiFi */}
+        <Field label="WiFi Network">
+          <input
+            type="text"
+            value={form.wifiNetwork}
+            onChange={(e) => update("wifiNetwork", e.target.value)}
+            placeholder="Network name"
+            className={inputClass}
+          />
+        </Field>
+        <Field label="WiFi Password">
+          <input
+            type="text"
+            value={form.wifiPassword}
+            onChange={(e) => update("wifiPassword", e.target.value)}
+            placeholder="Password"
+            className={inputClass}
+          />
+        </Field>
+
+        {/* Schedule */}
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="Check-in">
+            <input
+              type="text"
+              value={form.checkIn}
+              onChange={(e) => update("checkIn", e.target.value)}
+              placeholder="16:00"
+              className={inputClass}
+            />
+          </Field>
+          <Field label="Check-out">
+            <input
+              type="text"
+              value={form.checkOut}
+              onChange={(e) => update("checkOut", e.target.value)}
+              placeholder="10:00"
+              className={inputClass}
+            />
+          </Field>
+        </div>
+
+        {/* Access Codes */}
+        <fieldset>
+          <legend className="block text-sm font-medium text-midnight mb-1.5">
+            Access Codes
+          </legend>
+          <div className="space-y-2">
+            {form.accessCodes.map((code, i) => (
+              <div key={i} className="flex gap-2">
+                <input
+                  type="text"
+                  value={code.label}
+                  onChange={(e) => updateAccessCode(i, "label", e.target.value)}
+                  placeholder="Label"
+                  className={inputClass}
+                />
+                <input
+                  type="text"
+                  value={code.code}
+                  onChange={(e) => updateAccessCode(i, "code", e.target.value)}
+                  placeholder="Code"
+                  className={inputClass}
+                />
+                <button
+                  type="button"
+                  onClick={() => removeAccessCode(i)}
+                  className="shrink-0 text-sm text-spritz hover:text-spritz/80 font-medium"
+                >
+                  Remove
+                </button>
+              </div>
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={addAccessCode}
+            className="mt-2 text-sm text-alpine hover:text-alpine/80 font-medium"
+          >
+            + Add code
+          </button>
+        </fieldset>
+
+        {/* Emergency Contacts */}
+        <fieldset>
+          <legend className="block text-sm font-medium text-midnight mb-1.5">
+            Emergency Contacts
+          </legend>
+          <div className="space-y-3">
+            {form.emergencyContacts.map((contact, i) => (
+              <div key={i} className="space-y-2 rounded-xl bg-powder/50 p-3">
+                <input
+                  type="text"
+                  value={contact.name}
+                  onChange={(e) => updateContact(i, "name", e.target.value)}
+                  placeholder="Name"
+                  className={inputClass}
+                />
+                <input
+                  type="tel"
+                  value={contact.phone}
+                  onChange={(e) => updateContact(i, "phone", e.target.value)}
+                  placeholder="Phone"
+                  className={inputClass}
+                />
+                <input
+                  type="text"
+                  value={contact.role}
+                  onChange={(e) => updateContact(i, "role", e.target.value)}
+                  placeholder="Role (e.g. Owner, Caretaker)"
+                  className={inputClass}
+                />
+                <button
+                  type="button"
+                  onClick={() => removeContact(i)}
+                  className="text-sm text-spritz hover:text-spritz/80 font-medium"
+                >
+                  Remove contact
+                </button>
+              </div>
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={addContact}
+            className="mt-2 text-sm text-alpine hover:text-alpine/80 font-medium"
+          >
+            + Add contact
+          </button>
+        </fieldset>
+
+        {/* Notes */}
+        <Field label="Notes">
+          <textarea
+            value={form.notes}
+            onChange={(e) => update("notes", e.target.value)}
+            placeholder="Parking info, house rules, etc."
+            className={inputClass}
+            rows={3}
+          />
+        </Field>
+
+        {/* Actions */}
+        <div className="flex gap-3 pt-2">
+          <Button
+            variant="secondary"
+            onClick={onClose}
+            className="flex-1"
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            disabled={saving}
+            className="flex-1"
+          >
+            {saving ? "Saving…" : "Save"}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label className="block text-sm font-medium text-midnight mb-1.5">
+        {label}
+        {hint && (
+          <span className="font-normal text-mist ml-1">({hint})</span>
+        )}
+      </label>
+      {children}
+    </div>
+  );
+}

--- a/components/basecamp/EssentialsGrid.tsx
+++ b/components/basecamp/EssentialsGrid.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { Card } from "@/components/ui/Card";
+import { CopyButton } from "@/components/ui/CopyButton";
+import { RevealField } from "@/components/ui/RevealField";
+import type { Basecamp } from "@/lib/types";
+
+export function EssentialsGrid({ basecamp }: { basecamp: Basecamp }) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <WifiCard wifi={basecamp.wifi} />
+      <ScheduleCard checkIn={basecamp.checkIn} checkOut={basecamp.checkOut} />
+      <AccessCodesCard codes={basecamp.accessCodes} />
+      <EmergencyCard contacts={basecamp.emergencyContacts} />
+    </div>
+  );
+}
+
+function WifiCard({ wifi }: { wifi?: Basecamp["wifi"] }) {
+  return (
+    <Card>
+      <h3 className="text-sm font-semibold text-midnight mb-2">WiFi</h3>
+      {wifi?.network ? (
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-midnight/80">{wifi.network}</span>
+            <CopyButton text={wifi.network} />
+          </div>
+          {wifi.password && (
+            <RevealField label="Password" value={wifi.password} copyable />
+          )}
+        </div>
+      ) : (
+        <p className="text-sm text-mist">Not configured</p>
+      )}
+    </Card>
+  );
+}
+
+function ScheduleCard({
+  checkIn,
+  checkOut,
+}: {
+  checkIn?: string;
+  checkOut?: string;
+}) {
+  return (
+    <Card>
+      <h3 className="text-sm font-semibold text-midnight mb-2">Schedule</h3>
+      {checkIn || checkOut ? (
+        <div className="space-y-1">
+          {checkIn && (
+            <p className="text-sm text-midnight/80">
+              <span className="font-medium">Check-in:</span> {checkIn}
+            </p>
+          )}
+          {checkOut && (
+            <p className="text-sm text-midnight/80">
+              <span className="font-medium">Check-out:</span> {checkOut}
+            </p>
+          )}
+        </div>
+      ) : (
+        <p className="text-sm text-mist">Not configured</p>
+      )}
+    </Card>
+  );
+}
+
+function AccessCodesCard({
+  codes,
+}: {
+  codes?: Basecamp["accessCodes"];
+}) {
+  return (
+    <Card>
+      <h3 className="text-sm font-semibold text-midnight mb-2">
+        Access Codes
+      </h3>
+      {codes && codes.length > 0 ? (
+        <div className="space-y-2">
+          {codes.map((c, i) => (
+            <RevealField key={i} label={c.label} value={c.code} copyable />
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-mist">No access codes</p>
+      )}
+    </Card>
+  );
+}
+
+function EmergencyCard({
+  contacts,
+}: {
+  contacts?: Basecamp["emergencyContacts"];
+}) {
+  return (
+    <Card>
+      <h3 className="text-sm font-semibold text-midnight mb-2">
+        Emergency Contacts
+      </h3>
+      {contacts && contacts.length > 0 ? (
+        <div className="space-y-2">
+          {contacts.map((c, i) => (
+            <div key={i} className="text-sm">
+              <p className="font-medium text-midnight">{c.name}</p>
+              {c.role && <p className="text-mist text-xs">{c.role}</p>}
+              <a
+                href={`tel:${c.phone}`}
+                className="text-alpine hover:text-alpine/80 transition-colors"
+              >
+                {c.phone}
+              </a>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-mist">No emergency contacts</p>
+      )}
+    </Card>
+  );
+}

--- a/components/basecamp/MapEmbed.tsx
+++ b/components/basecamp/MapEmbed.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import type { Basecamp } from "@/lib/types";
+
+export function MapEmbed({
+  coordinates,
+  mapsUrl,
+}: {
+  coordinates?: Basecamp["coordinates"];
+  mapsUrl?: string;
+}) {
+  if (!coordinates?.lat || !coordinates?.lng) {
+    return (
+      <div className="w-full h-48 rounded-2xl bg-mist/20 flex items-center justify-center">
+        <p className="text-sm text-mist">No location set</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="w-full h-48 rounded-2xl overflow-hidden">
+        <iframe
+          title="Chalet location"
+          src={`https://maps.google.com/maps?q=${coordinates.lat},${coordinates.lng}&z=15&output=embed`}
+          className="w-full h-full border-0"
+          loading="lazy"
+          referrerPolicy="no-referrer-when-downgrade"
+        />
+      </div>
+      {mapsUrl && (
+        <a
+          href={mapsUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block text-sm text-alpine hover:text-alpine/80 font-medium transition-colors"
+        >
+          Open in Maps
+        </a>
+      )}
+    </div>
+  );
+}

--- a/components/ui/RevealField.tsx
+++ b/components/ui/RevealField.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState } from "react";
+import { CopyButton } from "@/components/ui/CopyButton";
+import { cn } from "@/lib/utils/cn";
+
+export function RevealField({
+  label,
+  value,
+  copyable = false,
+  className,
+}: {
+  label: string;
+  value: string;
+  copyable?: boolean;
+  className?: string;
+}) {
+  const [revealed, setRevealed] = useState(false);
+
+  if (!value) return null;
+
+  return (
+    <div className={cn("space-y-1", className)}>
+      <p className="text-sm font-medium text-midnight">{label}</p>
+      {revealed ? (
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-midnight/80 font-mono">{value}</span>
+          {copyable && <CopyButton text={value} />}
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setRevealed(true)}
+          className="text-sm text-alpine hover:text-alpine/80 font-medium transition-colors"
+        >
+          Tap to reveal
+        </button>
+      )}
+    </div>
+  );
+}

--- a/lib/actions/basecamp.ts
+++ b/lib/actions/basecamp.ts
@@ -1,0 +1,21 @@
+import { doc, setDoc, serverTimestamp } from "firebase/firestore";
+import { getDb } from "@/lib/firebase";
+import type { Basecamp } from "@/lib/types";
+
+type UpdatableFields = Omit<Partial<Basecamp>, "updatedAt" | "updatedBy">;
+
+export async function updateBasecamp(
+  fields: UpdatableFields,
+  updatedBy: string,
+) {
+  const db = getDb();
+  await setDoc(
+    doc(db, "basecamp", "current"),
+    {
+      ...fields,
+      updatedAt: serverTimestamp(),
+      updatedBy,
+    },
+    { merge: true },
+  );
+}

--- a/lib/hooks/useBasecamp.ts
+++ b/lib/hooks/useBasecamp.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { doc, onSnapshot } from "firebase/firestore";
+import { getDb } from "@/lib/firebase";
+import type { Basecamp } from "@/lib/types";
+
+export function useBasecamp() {
+  const [basecamp, setBasecamp] = useState<Basecamp | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const db = getDb();
+    const unsub = onSnapshot(
+      doc(db, "basecamp", "current"),
+      (snap) => {
+        setBasecamp(snap.exists() ? (snap.data() as Basecamp) : null);
+        setLoading(false);
+      },
+      (err) => {
+        setError(err);
+        setLoading(false);
+      },
+    );
+
+    return unsub;
+  }, []);
+
+  return { basecamp, loading, error };
+}


### PR DESCRIPTION
## Summary
- Implements full CRUD basecamp view for chalet info (address, WiFi, access codes, emergency contacts, map, notes)
- Establishes the **Firestore hook + action patterns** (`useBasecamp` / `updateBasecamp`) that all subsequent phases will replicate
- Adds `RevealField` UI component for sensitive data (WiFi passwords, access codes)

## New files
| File | Purpose |
|------|---------|
| `lib/hooks/useBasecamp.ts` | Real-time `onSnapshot` listener — template for future hooks |
| `lib/actions/basecamp.ts` | `updateBasecamp()` with `setDoc` merge — template for future actions |
| `components/ui/RevealField.tsx` | Click-to-reveal for sensitive data |
| `components/basecamp/MapEmbed.tsx` | Google Maps iframe embed from coordinates |
| `components/basecamp/AddressBlock.tsx` | Address display with copy button |
| `components/basecamp/EssentialsGrid.tsx` | 2-column grid: WiFi, Schedule, Access Codes, Emergency Contacts |
| `components/basecamp/EditBasecampModal.tsx` | Full form modal with dynamic arrays for codes/contacts |

## Test plan
- [ ] `npm run build` succeeds
- [ ] `npm run lint` passes
- [ ] Navigate to `/basecamp` → empty state renders with "Set Up Basecamp" button
- [ ] Click "Set Up Basecamp" → modal opens → fill fields → save → data appears
- [ ] Refresh page → data persists (Firestore)
- [ ] Click "Edit" → modal pre-populated → change a field → save → reflected immediately
- [ ] RevealField hides sensitive data, tap to reveal works
- [ ] CopyButton copies address/WiFi to clipboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)