### PR TITLE
Add Phase 4: Rostrum view with attendance timeline

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -348,16 +348,16 @@ apres-ski/
 
 **Dependencies:** Phase 3 (Firebase patterns established).
 
-- [ ] **4.1** Data hooks
+- [x] **4.1** Data hooks
   - `lib/hooks/useParticipants.ts` -- `onSnapshot` on `participants` collection
   - `lib/hooks/useAttendance.ts` -- `onSnapshot` on `attendance` collection
   - `lib/hooks/useTrip.ts` -- `onSnapshot` on `doc(db, 'trips', 'current')`
-- [ ] **4.2** Write actions: `lib/actions/attendance.ts`
+- [x] **4.2** Write actions: `lib/actions/attendance.ts`
   - `toggleAttendance(participantId, date, currentlyPresent)` -- sets/deletes attendance doc using composite ID `{participantId}_{date}`
-- [ ] **4.3** Utilities
+- [x] **4.3** Utilities
   - `lib/utils/dates.ts` -- `getDateRange(start, end)` -> `YYYY-MM-DD[]`, `formatDateShort(date)` -> `"Fri 12"`, `isToday(date)` -> boolean
-- [ ] **4.4** Page: `app/rostrum/page.tsx`
-- [ ] **4.5** Components
+- [x] **4.4** Page: `app/rostrum/page.tsx`
+- [x] **4.5** Components
   - `components/rostrum/TimelineMatrix.tsx` -- horizontally scrollable container, sticky left column (names + avatars), date header row
   - `components/rostrum/TimelineRow.tsx` -- one participant's row with colored presence bars
   - `components/rostrum/TimelineCell.tsx` -- tap to toggle, colored (participant color) when present, grey when absent

--- a/app/rostrum/page.tsx
+++ b/app/rostrum/page.tsx
@@ -1,14 +1,95 @@
+"use client";
+
+import { useState } from "react";
 import { Card } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+import { useTrip } from "@/lib/hooks/useTrip";
+import { useParticipants } from "@/lib/hooks/useParticipants";
+import { useAttendance } from "@/lib/hooks/useAttendance";
+import { TimelineMatrix } from "@/components/rostrum/TimelineMatrix";
+import { EditTripModal } from "@/components/rostrum/EditTripModal";
 
 export default function RostrumPage() {
+  const { trip, loading: tripLoading } = useTrip();
+  const { participants, loading: participantsLoading } = useParticipants();
+  const { attendance, loading: attendanceLoading } = useAttendance();
+  const [editOpen, setEditOpen] = useState(false);
+
+  const loading = tripLoading || participantsLoading || attendanceLoading;
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold text-midnight">Rostrum</h1>
+        <Card className="animate-pulse h-48"><span /></Card>
+      </div>
+    );
+  }
+
+  if (!trip) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold text-midnight">Rostrum</h1>
+        <Card>
+          <div className="text-center py-8 space-y-3">
+            <p className="text-mist">No trip set up yet</p>
+            <Button onClick={() => setEditOpen(true)}>Set Up Trip</Button>
+          </div>
+        </Card>
+        <EditTripModal
+          isOpen={editOpen}
+          onClose={() => setEditOpen(false)}
+          trip={null}
+        />
+      </div>
+    );
+  }
+
+  if (participants.length === 0) {
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold text-midnight">Rostrum</h1>
+          <Button variant="secondary" onClick={() => setEditOpen(true)}>
+            Edit Trip
+          </Button>
+        </div>
+        <Card>
+          <div className="text-center py-8 space-y-3">
+            <p className="text-mist">No participants yet — share the link to invite friends</p>
+          </div>
+        </Card>
+        <EditTripModal
+          isOpen={editOpen}
+          onClose={() => setEditOpen(false)}
+          trip={trip}
+        />
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-4">
-      <h1 className="text-2xl font-bold text-midnight">Rostrum</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-midnight">Rostrum</h1>
+        <Button variant="secondary" onClick={() => setEditOpen(true)}>
+          Edit Trip
+        </Button>
+      </div>
+
       <Card>
-        <p className="text-mist">
-          Attendance tracking will appear here.
-        </p>
+        <TimelineMatrix
+          trip={trip}
+          participants={participants}
+          attendance={attendance}
+        />
       </Card>
+
+      <EditTripModal
+        isOpen={editOpen}
+        onClose={() => setEditOpen(false)}
+        trip={trip}
+      />
     </div>
   );
 }

--- a/components/rostrum/EditTripModal.tsx
+++ b/components/rostrum/EditTripModal.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState } from "react";
+import { Modal } from "@/components/ui/Modal";
+import { Button } from "@/components/ui/Button";
+import { updateTrip } from "@/lib/actions/trip";
+import type { Trip } from "@/lib/types";
+
+const inputClass =
+  "w-full rounded-xl border border-mist/30 bg-powder px-4 py-2.5 text-midnight placeholder:text-mist focus:outline-none focus:ring-2 focus:ring-alpine/50";
+
+export function EditTripModal({
+  isOpen,
+  onClose,
+  trip,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  trip: Trip | null;
+}) {
+  const [name, setName] = useState(trip?.name ?? "");
+  const [startDate, setStartDate] = useState(trip?.startDate ?? "");
+  const [endDate, setEndDate] = useState(trip?.endDate ?? "");
+  const [saving, setSaving] = useState(false);
+
+  const isValid =
+    name.trim().length > 0 && startDate && endDate && startDate <= endDate;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!isValid) return;
+
+    setSaving(true);
+    try {
+      await updateTrip({ name: name.trim(), startDate, endDate });
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={trip ? "Edit Trip" : "Set Up Trip"}>
+      <form onSubmit={handleSubmit} className="space-y-5">
+        <div>
+          <label className="block text-sm font-medium text-midnight mb-1.5">
+            Trip Name
+          </label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Ski Week 2026"
+            className={inputClass}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="block text-sm font-medium text-midnight mb-1.5">
+              Start Date
+            </label>
+            <input
+              type="date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              className={inputClass}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-midnight mb-1.5">
+              End Date
+            </label>
+            <input
+              type="date"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+              className={inputClass}
+            />
+          </div>
+        </div>
+
+        <div className="flex gap-3 pt-2">
+          <Button variant="secondary" onClick={onClose} className="flex-1">
+            Cancel
+          </Button>
+          <Button type="submit" disabled={saving || !isValid} className="flex-1">
+            {saving ? "Saving\u2026" : "Save"}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/components/rostrum/TimelineCell.tsx
+++ b/components/rostrum/TimelineCell.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { cn } from "@/lib/utils/cn";
+
+export function TimelineCell({
+  isPresent,
+  participantColor,
+  isToday,
+  onToggle,
+}: {
+  isPresent: boolean;
+  participantColor: string;
+  isToday: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className={cn(
+        "w-12 h-12 rounded-lg border-2 transition-colors shrink-0",
+        !isPresent && isToday && "bg-alpine/5 border-alpine/20",
+        !isPresent && !isToday && "bg-powder border-mist/20",
+      )}
+      style={isPresent ? { backgroundColor: participantColor, borderColor: participantColor } : undefined}
+    />
+  );
+}

--- a/components/rostrum/TimelineMatrix.tsx
+++ b/components/rostrum/TimelineMatrix.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useMemo } from "react";
+import { cn } from "@/lib/utils/cn";
+import { getDateRange, formatDateShort, isToday } from "@/lib/utils/dates";
+import { TimelineRow } from "@/components/rostrum/TimelineRow";
+import { toggleAttendance } from "@/lib/actions/attendance";
+import type { Trip, Participant, Attendance } from "@/lib/types";
+
+export function TimelineMatrix({
+  trip,
+  participants,
+  attendance,
+}: {
+  trip: Trip;
+  participants: Participant[];
+  attendance: Attendance[];
+}) {
+  const { dates, todayStr, attendanceMap } = useMemo(() => {
+    const dates = getDateRange(trip.startDate, trip.endDate);
+    const todayStr = dates.find(isToday) ?? "";
+
+    const attendanceMap = new Map<string, Set<string>>();
+    for (const a of attendance) {
+      let set = attendanceMap.get(a.participantId);
+      if (!set) {
+        set = new Set();
+        attendanceMap.set(a.participantId, set);
+      }
+      set.add(a.date);
+    }
+
+    return { dates, todayStr, attendanceMap };
+  }, [trip.startDate, trip.endDate, attendance]);
+
+  function handleToggle(participantId: string, date: string, currentlyPresent: boolean) {
+    const p = participants.find((p) => p.id === participantId);
+    if (!p) return;
+    toggleAttendance({ id: p.id, name: p.name, color: p.color }, date, currentlyPresent);
+  }
+
+  return (
+    <div className="overflow-x-auto -mx-5 px-5">
+      <div className="inline-flex flex-col min-w-max gap-2">
+        {/* Date header row */}
+        <div className="flex items-end gap-2">
+          <div className="w-32 shrink-0" />
+          {dates.map((date) => {
+            const label = formatDateShort(date);
+            const [weekday, day] = label.split(" ");
+            const today = date === todayStr;
+            return (
+              <div
+                key={date}
+                className={cn(
+                  "w-12 shrink-0 text-center text-xs leading-tight",
+                  today ? "text-alpine font-semibold" : "text-mist",
+                )}
+              >
+                <div>{weekday}</div>
+                <div>{day}</div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Participant rows */}
+        {participants.map((p) => (
+          <TimelineRow
+            key={p.id}
+            participant={p}
+            dates={dates}
+            attendanceSet={attendanceMap.get(p.id) ?? new Set()}
+            todayStr={todayStr}
+            onToggle={handleToggle}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/rostrum/TimelineRow.tsx
+++ b/components/rostrum/TimelineRow.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { Avatar } from "@/components/ui/Avatar";
+import { TimelineCell } from "@/components/rostrum/TimelineCell";
+import type { Participant } from "@/lib/types";
+
+export function TimelineRow({
+  participant,
+  dates,
+  attendanceSet,
+  todayStr,
+  onToggle,
+}: {
+  participant: Participant;
+  dates: string[];
+  attendanceSet: Set<string>;
+  todayStr: string;
+  onToggle: (participantId: string, date: string, currentlyPresent: boolean) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <div className="w-32 shrink-0 sticky left-0 bg-glacier z-10 flex items-center gap-2 pr-2">
+        <Avatar initials={participant.avatar} color={participant.color} size="sm" />
+        <span className="text-sm font-medium text-midnight truncate">
+          {participant.name}
+        </span>
+      </div>
+      {dates.map((date) => {
+        const present = attendanceSet.has(date);
+        return (
+          <TimelineCell
+            key={date}
+            isPresent={present}
+            participantColor={participant.color}
+            isToday={date === todayStr}
+            onToggle={() => onToggle(participant.id, date, present)}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/lib/actions/attendance.ts
+++ b/lib/actions/attendance.ts
@@ -1,0 +1,26 @@
+import { doc, setDoc, deleteDoc, serverTimestamp } from "firebase/firestore";
+import { getDb } from "@/lib/firebase";
+
+export async function toggleAttendance(
+  participant: { id: string; name: string; color: string },
+  date: string,
+  currentlyPresent: boolean,
+) {
+  const db = getDb();
+  const docId = `${participant.id}_${date}`;
+  const ref = doc(db, "attendance", docId);
+
+  if (currentlyPresent) {
+    await deleteDoc(ref);
+  } else {
+    await setDoc(ref, {
+      participantId: participant.id,
+      participantName: participant.name,
+      participantColor: participant.color,
+      date,
+      present: true,
+      tripId: "current",
+      updatedAt: serverTimestamp(),
+    });
+  }
+}

--- a/lib/actions/trip.ts
+++ b/lib/actions/trip.ts
@@ -1,0 +1,17 @@
+import { doc, setDoc, serverTimestamp } from "firebase/firestore";
+import { getDb } from "@/lib/firebase";
+import type { Trip } from "@/lib/types";
+
+type UpdatableFields = Omit<Partial<Trip>, "updatedAt" | "createdAt">;
+
+export async function updateTrip(fields: UpdatableFields) {
+  const db = getDb();
+  await setDoc(
+    doc(db, "trips", "current"),
+    {
+      ...fields,
+      updatedAt: serverTimestamp(),
+    },
+    { merge: true },
+  );
+}

--- a/lib/hooks/useAttendance.ts
+++ b/lib/hooks/useAttendance.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { collection, onSnapshot } from "firebase/firestore";
+import { getDb } from "@/lib/firebase";
+import type { Attendance } from "@/lib/types";
+
+export function useAttendance() {
+  const [attendance, setAttendance] = useState<Attendance[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const db = getDb();
+    const unsub = onSnapshot(
+      collection(db, "attendance"),
+      (snap) => {
+        setAttendance(
+          snap.docs.map((d) => ({ ...d.data(), id: d.id }) as Attendance),
+        );
+        setLoading(false);
+      },
+      (err) => {
+        setError(err);
+        setLoading(false);
+      },
+    );
+
+    return unsub;
+  }, []);
+
+  return { attendance, loading, error };
+}

--- a/lib/hooks/useParticipants.ts
+++ b/lib/hooks/useParticipants.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { collection, onSnapshot } from "firebase/firestore";
+import { getDb } from "@/lib/firebase";
+import type { Participant } from "@/lib/types";
+
+export function useParticipants() {
+  const [participants, setParticipants] = useState<Participant[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const db = getDb();
+    const unsub = onSnapshot(
+      collection(db, "participants"),
+      (snap) => {
+        setParticipants(
+          snap.docs.map((d) => ({ ...d.data(), id: d.id }) as Participant),
+        );
+        setLoading(false);
+      },
+      (err) => {
+        setError(err);
+        setLoading(false);
+      },
+    );
+
+    return unsub;
+  }, []);
+
+  return { participants, loading, error };
+}

--- a/lib/hooks/useTrip.ts
+++ b/lib/hooks/useTrip.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { doc, onSnapshot } from "firebase/firestore";
+import { getDb } from "@/lib/firebase";
+import type { Trip } from "@/lib/types";
+
+export function useTrip() {
+  const [trip, setTrip] = useState<Trip | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const db = getDb();
+    const unsub = onSnapshot(
+      doc(db, "trips", "current"),
+      (snap) => {
+        setTrip(snap.exists() ? (snap.data() as Trip) : null);
+        setLoading(false);
+      },
+      (err) => {
+        setError(err);
+        setLoading(false);
+      },
+    );
+
+    return unsub;
+  }, []);
+
+  return { trip, loading, error };
+}

--- a/lib/utils/dates.ts
+++ b/lib/utils/dates.ts
@@ -1,0 +1,28 @@
+export function getDateRange(start: string, end: string): string[] {
+  const dates: string[] = [];
+  const current = new Date(`${start}T00:00:00`);
+  const last = new Date(`${end}T00:00:00`);
+
+  while (current <= last) {
+    const y = current.getFullYear();
+    const m = String(current.getMonth() + 1).padStart(2, "0");
+    const d = String(current.getDate()).padStart(2, "0");
+    dates.push(`${y}-${m}-${d}`);
+    current.setDate(current.getDate() + 1);
+  }
+
+  return dates;
+}
+
+export function formatDateShort(dateStr: string): string {
+  const date = new Date(`${dateStr}T00:00:00`);
+  return date.toLocaleDateString("en-US", { weekday: "short", day: "numeric" });
+}
+
+export function isToday(dateStr: string): boolean {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, "0");
+  const d = String(now.getDate()).padStart(2, "0");
+  return dateStr === `${y}-${m}-${d}`;
+}


### PR DESCRIPTION
## Summary
- Add interactive attendance timeline grid where participants toggle daily presence per trip day
- Add trip setup/edit modal with name and start/end date fields
- Add date utilities (`getDateRange`, `formatDateShort`, `isToday`), 3 Firestore hooks (`useTrip`, `useParticipants`, `useAttendance`), and 2 action modules (`trip.ts`, `attendance.ts`)
- Rostrum page follows established loading → empty → main state pattern from Phase 3

## New files (11)
- `lib/utils/dates.ts` — date range generation, formatting, today detection
- `lib/hooks/useTrip.ts` — real-time listener on `trips/current`
- `lib/hooks/useParticipants.ts` — real-time listener on `participants` collection
- `lib/hooks/useAttendance.ts` — real-time listener on `attendance` collection
- `lib/actions/trip.ts` — `updateTrip` with merge + serverTimestamp
- `lib/actions/attendance.ts` — `toggleAttendance` (setDoc/deleteDoc toggle)
- `components/rostrum/TimelineCell.tsx` — toggle button with color/today states
- `components/rostrum/TimelineRow.tsx` — sticky name/avatar column + cells
- `components/rostrum/TimelineMatrix.tsx` — date header + participant rows, horizontal scroll
- `components/rostrum/EditTripModal.tsx` — trip name + date range form

## Test plan
- [ ] Navigate to `/rostrum` → see "Set Up Trip" empty state
- [ ] Create trip via modal → timeline grid appears with date columns
- [ ] Tap cells to toggle → colored when present, empty when absent
- [ ] Today's column has blue highlight
- [ ] Grid scrolls horizontally on mobile
- [ ] Refresh → data persists (Firestore)
- [ ] Second browser tab → real-time sync
- [ ] `npm run build` succeeds, `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)