### PR TITLE
Add Phase 6: Hub dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,4 +75,4 @@ All interfaces defined in `lib/types.ts`. Uses Firestore `Timestamp` type.
 
 ## Project Status
 
-Phases 1-5 complete (scaffolding, app shell, basecamp CRUD, rostrum attendance, feasts meal planning). Phases 6-7 remain (hub dashboard, polish). See `PLAN.md` for full roadmap.
+Phases 1-6 complete (scaffolding, app shell, basecamp CRUD, rostrum attendance, feasts meal planning, hub dashboard). Phase 7 remains (polish). See `PLAN.md` for full roadmap.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,101 @@
+"use client";
+
+import { useMemo } from "react";
 import { Card } from "@/components/ui/Card";
+import { HeroHeader } from "@/components/hub/HeroHeader";
+import { TodaySnapshot } from "@/components/hub/TodaySnapshot";
+import { QuickActions } from "@/components/hub/QuickActions";
+import { useTrip } from "@/lib/hooks/useTrip";
+import { useParticipants } from "@/lib/hooks/useParticipants";
+import { useAttendance } from "@/lib/hooks/useAttendance";
+import { useMeals } from "@/lib/hooks/useMeals";
+import { useBasecamp } from "@/lib/hooks/useBasecamp";
+import { getCountdownText, getTodayString } from "@/lib/utils/countdown";
+import type { Participant } from "@/lib/types";
 
 export default function HubPage() {
+  const { trip, loading: tripLoading } = useTrip();
+  const { participants, loading: participantsLoading } = useParticipants();
+  const { attendance, loading: attendanceLoading } = useAttendance();
+  const { meals, loading: mealsLoading } = useMeals();
+  const { basecamp, loading: basecampLoading } = useBasecamp();
+
+  const loading =
+    tripLoading ||
+    participantsLoading ||
+    attendanceLoading ||
+    mealsLoading ||
+    basecampLoading;
+
+  const countdownText = useMemo(() => {
+    if (!trip) return null;
+    return getCountdownText(trip.startDate, trip.endDate);
+  }, [trip]);
+
+  const today = useMemo(() => getTodayString(), []);
+
+  const todayMeal = useMemo(
+    () => meals.find((m) => m.date === today),
+    [meals, today],
+  );
+
+  const { arrivals, departures } = useMemo(() => {
+    if (!attendance.length || !participants.length) {
+      return { arrivals: [] as Participant[], departures: [] as Participant[] };
+    }
+
+    const presentByParticipant = new Map<string, string[]>();
+    for (const a of attendance) {
+      if (!a.present) continue;
+      const dates = presentByParticipant.get(a.participantId) || [];
+      dates.push(a.date);
+      presentByParticipant.set(a.participantId, dates);
+    }
+
+    const arrivingIds: string[] = [];
+    const departingIds: string[] = [];
+
+    for (const [pid, dates] of presentByParticipant) {
+      dates.sort();
+      if (dates[0] === today) arrivingIds.push(pid);
+      if (dates[dates.length - 1] === today) departingIds.push(pid);
+    }
+
+    const participantMap = new Map(participants.map((p) => [p.id, p]));
+    return {
+      arrivals: arrivingIds
+        .map((id) => participantMap.get(id))
+        .filter((p): p is Participant => !!p),
+      departures: departingIds
+        .map((id) => participantMap.get(id))
+        .filter((p): p is Participant => !!p),
+    };
+  }, [attendance, participants, today]);
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        <div className="h-28 rounded-2xl bg-gradient-to-br from-alpine to-midnight animate-pulse" />
+        <Card className="animate-pulse h-32">
+          <span />
+        </Card>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-4">
-      <h1 className="text-2xl font-bold text-midnight">Hub</h1>
-      <Card>
-        <p className="text-mist">
-          Welcome to Apres-Ski. Your trip dashboard will appear here.
-        </p>
-      </Card>
+      <HeroHeader
+        tripName={trip?.name ?? null}
+        countdownText={countdownText}
+      />
+      <TodaySnapshot
+        arrivals={arrivals}
+        departures={departures}
+        todayMeal={todayMeal}
+        participants={participants}
+      />
+      <QuickActions basecamp={basecamp} />
     </div>
   );
 }

--- a/components/hub/HeroHeader.tsx
+++ b/components/hub/HeroHeader.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+export function HeroHeader({
+  tripName,
+  countdownText,
+}: {
+  tripName: string | null;
+  countdownText: string | null;
+}) {
+  return (
+    <div className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-alpine to-midnight p-6 md:p-8 text-white">
+      {/* Mountain silhouette */}
+      <svg
+        className="absolute inset-0 w-full h-full opacity-10"
+        viewBox="0 0 800 200"
+        preserveAspectRatio="xMidYMax slice"
+        aria-hidden="true"
+      >
+        <polygon points="0,200 100,80 200,150 300,50 400,120 500,30 600,100 700,60 800,140 800,200" fill="white" />
+      </svg>
+      <div className="relative">
+        <h1 className="text-2xl md:text-3xl font-bold">
+          {tripName || "Apres-Ski"}
+        </h1>
+        {countdownText && (
+          <p className="mt-1 text-white/80 text-lg">{countdownText}</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/hub/QuickActions.tsx
+++ b/components/hub/QuickActions.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Card } from "@/components/ui/Card";
+import { CopyButton } from "@/components/ui/CopyButton";
+import type { Basecamp } from "@/lib/types";
+
+export function QuickActions({
+  basecamp,
+}: {
+  basecamp: Basecamp | null;
+}) {
+  if (!basecamp) return null;
+
+  const hasNavigate = !!basecamp.mapsUrl;
+  const hasWifi = !!basecamp.wifi?.network;
+
+  if (!hasNavigate && !hasWifi) return null;
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      {hasNavigate && (
+        <Card>
+          <a
+            href={basecamp.mapsUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block"
+          >
+            <div className="flex items-center gap-3">
+              <div className="w-10 h-10 rounded-full bg-alpine/10 flex items-center justify-center text-alpine shrink-0">
+                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M10 2C6.686 2 4 4.686 4 8c0 4.5 6 10 6 10s6-5.5 6-10c0-3.314-2.686-6-6-6z" />
+                  <circle cx="10" cy="8" r="2" />
+                </svg>
+              </div>
+              <div className="min-w-0">
+                <p className="text-sm font-semibold text-midnight">
+                  Navigate to Chalet
+                </p>
+                {basecamp.address && (
+                  <p className="text-xs text-mist truncate">
+                    {basecamp.address}
+                  </p>
+                )}
+              </div>
+            </div>
+          </a>
+        </Card>
+      )}
+      {hasWifi && (
+        <Card>
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-full bg-pine/10 flex items-center justify-center text-pine shrink-0">
+              <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M2 7a14 14 0 0 1 16 0M5 10.5a9 9 0 0 1 10 0M8 14a4 4 0 0 1 4 0" />
+                <circle cx="10" cy="17" r="0.5" fill="currentColor" />
+              </svg>
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-semibold text-midnight">WiFi</p>
+              <p className="text-xs text-mist">{basecamp.wifi.network}</p>
+              {basecamp.wifi.password && (
+                <div className="flex items-center gap-2 mt-1">
+                  <code className="text-xs bg-powder px-1.5 py-0.5 rounded text-midnight">
+                    {basecamp.wifi.password}
+                  </code>
+                  <CopyButton text={basecamp.wifi.password} label="Copy" />
+                </div>
+              )}
+            </div>
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/components/hub/TodaySnapshot.tsx
+++ b/components/hub/TodaySnapshot.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { Card } from "@/components/ui/Card";
+import { Avatar } from "@/components/ui/Avatar";
+import { getInitials } from "@/lib/utils/colors";
+import type { Participant, Meal } from "@/lib/types";
+
+export function TodaySnapshot({
+  arrivals,
+  departures,
+  todayMeal,
+  participants,
+}: {
+  arrivals: Participant[];
+  departures: Participant[];
+  todayMeal: Meal | undefined;
+  participants: Participant[];
+}) {
+  const dinnerClaimed = todayMeal?.dinner.status !== "unassigned";
+  const aperoClaimed = todayMeal?.apero.status !== "unassigned";
+
+  const chefParticipant = dinnerClaimed
+    ? participants.find((p) => p.id === todayMeal?.dinner.chefParticipantId)
+    : undefined;
+
+  const aperoParticipant = aperoClaimed
+    ? participants.find((p) => p.id === todayMeal?.apero.assignedParticipantId)
+    : undefined;
+
+  const hasContent =
+    arrivals.length > 0 ||
+    departures.length > 0 ||
+    dinnerClaimed ||
+    aperoClaimed;
+
+  return (
+    <Card>
+      <h2 className="text-lg font-semibold text-midnight mb-3">Today</h2>
+      {!hasContent ? (
+        <p className="text-mist text-sm">Nothing scheduled for today</p>
+      ) : (
+        <div className="space-y-3">
+          {arrivals.length > 0 && (
+            <Row
+              icon={
+                <div className="w-8 h-8 rounded-full bg-alpine/10 flex items-center justify-center text-alpine">
+                  <ArrowDownIcon />
+                </div>
+              }
+              label="Arriving"
+              participants={arrivals}
+            />
+          )}
+          {departures.length > 0 && (
+            <Row
+              icon={
+                <div className="w-8 h-8 rounded-full bg-pine/10 flex items-center justify-center text-pine">
+                  <ArrowUpIcon />
+                </div>
+              }
+              label="Departing"
+              participants={departures}
+            />
+          )}
+          {dinnerClaimed && todayMeal && (
+            <div className="flex items-center gap-3">
+              <div className="w-8 h-8 rounded-full bg-alpine/10 flex items-center justify-center text-alpine">
+                <ChefIcon />
+              </div>
+              <div className="flex items-center gap-2 min-w-0">
+                {chefParticipant && (
+                  <Avatar
+                    initials={getInitials(chefParticipant.name)}
+                    color={chefParticipant.color}
+                    size="sm"
+                  />
+                )}
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-midnight">
+                    Dinner — {todayMeal.dinner.chefName}
+                  </p>
+                  {todayMeal.dinner.menu && (
+                    <p className="text-xs text-mist truncate">
+                      {todayMeal.dinner.menu}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+          {aperoClaimed && todayMeal && (
+            <div className="flex items-center gap-3">
+              <div className="w-8 h-8 rounded-full bg-spritz/10 flex items-center justify-center text-spritz">
+                <GlassIcon />
+              </div>
+              <div className="flex items-center gap-2 min-w-0">
+                {aperoParticipant && (
+                  <Avatar
+                    initials={getInitials(aperoParticipant.name)}
+                    color={aperoParticipant.color}
+                    size="sm"
+                  />
+                )}
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-midnight">
+                    Apero — {todayMeal.apero.assignedTo}
+                  </p>
+                  {todayMeal.apero.notes && (
+                    <p className="text-xs text-mist truncate">
+                      {todayMeal.apero.notes}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function Row({
+  icon,
+  label,
+  participants,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  participants: Participant[];
+}) {
+  return (
+    <div className="flex items-center gap-3">
+      {icon}
+      <div className="flex items-center gap-2 min-w-0">
+        <div className="flex -space-x-2">
+          {participants.slice(0, 5).map((p) => (
+            <Avatar
+              key={p.id}
+              initials={getInitials(p.name)}
+              color={p.color}
+              size="sm"
+            />
+          ))}
+        </div>
+        <p className="text-sm text-midnight truncate">
+          <span className="font-medium">{label}:</span>{" "}
+          {participants.map((p) => p.name).join(", ")}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function ArrowDownIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M8 3v10M4 9l4 4 4-4" />
+    </svg>
+  );
+}
+
+function ArrowUpIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M8 13V3M4 7l4-4 4 4" />
+    </svg>
+  );
+}
+
+function ChefIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M5 14h6M4 10h8M5 10V7M11 10V7" />
+      <circle cx="8" cy="4" r="2.5" />
+    </svg>
+  );
+}
+
+function GlassIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M4 2l1.5 6H10.5L12 2H4zM7.5 8v5M5.5 13h4" />
+    </svg>
+  );
+}

--- a/lib/utils/countdown.ts
+++ b/lib/utils/countdown.ts
@@ -1,0 +1,34 @@
+export function getTodayString(): string {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, "0");
+  const d = String(now.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+export function getCountdownText(startDate: string, endDate: string): string {
+  const today = new Date(`${getTodayString()}T00:00:00`);
+  const start = new Date(`${startDate}T00:00:00`);
+  const end = new Date(`${endDate}T00:00:00`);
+
+  if (today < start) {
+    const diff = Math.ceil(
+      (start.getTime() - today.getTime()) / (1000 * 60 * 60 * 24),
+    );
+    return diff === 1 ? "1 day until the trip!" : `${diff} days until the trip!`;
+  }
+
+  if (today > end) {
+    return "Hope you had fun!";
+  }
+
+  const dayNum =
+    Math.floor(
+      (today.getTime() - start.getTime()) / (1000 * 60 * 60 * 24),
+    ) + 1;
+  const totalDays =
+    Math.floor(
+      (end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24),
+    ) + 1;
+  return `Day ${dayNum} of ${totalDays}`;
+}


### PR DESCRIPTION
## Summary
- **HeroHeader**: Gradient banner (`alpine` → `midnight`) with SVG mountain silhouette, trip name, and countdown text (before/during/after trip)
- **TodaySnapshot**: Card showing today's arrivals, departures, dinner chef, and apero assignment with avatar stacks and color-coded icons
- **QuickActions**: Navigate-to-chalet link (opens Maps) and WiFi card with copy-to-clipboard password
- **Hub page rewrite**: Wires all 5 existing hooks with `useMemo` derivations for countdown, today's meal, and arrival/departure detection

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] Hub shows gradient hero with "Apres-Ski" when no trip exists
- [ ] After setting up a trip in Rostrum: countdown appears
- [ ] After toggling attendance: arrivals/departures show in TodaySnapshot
- [ ] After claiming meals in Feasts: chef/apero info appears in TodaySnapshot
- [ ] After configuring Basecamp: QuickActions shows navigate + WiFi cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)