### PR TITLE
Show Add button on Crew page during loading state

### DIFF
--- a/app/crew/page.tsx
+++ b/app/crew/page.tsx
@@ -14,8 +14,12 @@ export default function CrewPage() {
   if (loading) {
     return (
       <div className="space-y-4">
-        <h1 className="text-2xl font-bold text-midnight">Crew</h1>
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold text-midnight">Crew</h1>
+          <Button onClick={() => setShowAdd(true)}>+ Add</Button>
+        </div>
         <Card className="animate-pulse h-48"><span /></Card>
+        <AddCrewModal isOpen={showAdd} onClose={() => setShowAdd(false)} />
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- The "+ Add" button and `AddCrewModal` were only rendered after the Firestore participant list finished loading
- If Firestore was slow to connect (or the database didn't exist yet), the Crew page showed only a heading and empty skeleton card with no way to add members
- Now the button and modal are available in both loading and loaded states

## Test plan
- [ ] Open the Crew page — verify the "+ Add" button is visible immediately (even before Firestore responds)
- [ ] Click "+ Add" while loading — verify the modal opens and works correctly
- [ ] After loading completes, verify the button and participant list render as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)