### PR TITLE
Add Firebase config for Firestore rules deployment

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "apres-ski-13735"
+  }
+}

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,6 @@
+{
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `firebase.json` and `.firebaserc` so Firestore rules can be deployed via `npx firebase-tools deploy --only firestore:rules`
- Fixes "Missing or insufficient permissions" error when adding crew members — the local `firestore.rules` (open read/write) were never deployed to the project

## Test plan
- [ ] Verify adding a crew member no longer throws a permissions error
- [ ] Verify `npx firebase-tools deploy --only firestore:rules` works from the repo root

🤖 Generated with [Claude Code](https://claude.com/claude-code)