### PR TITLE
Sort crew lists by color then name, fix basecamp save

### DIFF
--- a/app/crew/page.tsx
+++ b/app/crew/page.tsx
@@ -7,6 +7,7 @@ import { Avatar } from "@/components/ui/Avatar";
 import { AddCrewModal } from "@/components/crew/AddCrewModal";
 import { EditCrewModal } from "@/components/crew/EditCrewModal";
 import { useParticipants } from "@/lib/hooks/useParticipants";
+import { sortParticipants } from "@/lib/utils/colors";
 import type { Participant } from "@/lib/types";
 
 export default function CrewPage() {
@@ -27,11 +28,7 @@ export default function CrewPage() {
     );
   }
 
-  const sorted = [...participants].sort((a, b) => {
-    const aTime = a.joinedAt?.toMillis?.() ?? 0;
-    const bTime = b.joinedAt?.toMillis?.() ?? 0;
-    return aTime - bTime;
-  });
+  const sorted = sortParticipants(participants);
 
   return (
     <div className="space-y-4">

--- a/components/basecamp/EditBasecampModal.tsx
+++ b/components/basecamp/EditBasecampModal.tsx
@@ -199,7 +199,7 @@ export function EditBasecampModal({
         {/* Maps URL */}
         <Field label="Maps URL">
           <input
-            type="url"
+            type="text"
             value={form.mapsUrl}
             onChange={(e) => update("mapsUrl", e.target.value)}
             placeholder="https://maps.app.goo.gl/..."

--- a/components/hub/TodaySnapshot.tsx
+++ b/components/hub/TodaySnapshot.tsx
@@ -2,7 +2,7 @@
 
 import { Card } from "@/components/ui/Card";
 import { Avatar } from "@/components/ui/Avatar";
-import { getInitials } from "@/lib/utils/colors";
+import { getInitials, sortParticipants } from "@/lib/utils/colors";
 import type { Participant, Meal } from "@/lib/types";
 
 export function TodaySnapshot({
@@ -134,7 +134,7 @@ function Row({
       {icon}
       <div className="flex items-center gap-2 min-w-0">
         <div className="flex -space-x-2">
-          {participants.slice(0, 5).map((p) => (
+          {sortParticipants(participants).slice(0, 5).map((p) => (
             <Avatar
               key={p.id}
               initials={getInitials(p.name)}

--- a/components/rostrum/TimelineMatrix.tsx
+++ b/components/rostrum/TimelineMatrix.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils/cn";
 import { getDateRange, formatDateShort, isToday } from "@/lib/utils/dates";
 import { TimelineRow } from "@/components/rostrum/TimelineRow";
 import { toggleAttendance } from "@/lib/actions/attendance";
+import { sortParticipants } from "@/lib/utils/colors";
 import type { Trip, Participant, Attendance } from "@/lib/types";
 
 export function TimelineMatrix({
@@ -65,7 +66,7 @@ export function TimelineMatrix({
         </div>
 
         {/* Participant rows */}
-        {participants.map((p) => (
+        {sortParticipants(participants).map((p) => (
           <TimelineRow
             key={p.id}
             participant={p}

--- a/lib/utils/colors.ts
+++ b/lib/utils/colors.ts
@@ -11,6 +11,21 @@ export const PARTICIPANT_COLORS = [
   { name: "Powder Pink", hex: "#EC4899" },
 ] as const;
 
+const COLOR_ORDER: Map<string, number> = new Map(
+  PARTICIPANT_COLORS.map((c, i) => [c.hex, i]),
+);
+
+export function sortParticipants<T extends { color: string; name: string }>(
+  list: T[],
+): T[] {
+  return [...list].sort((a, b) => {
+    const ca = COLOR_ORDER.get(a.color) ?? PARTICIPANT_COLORS.length;
+    const cb = COLOR_ORDER.get(b.color) ?? PARTICIPANT_COLORS.length;
+    if (ca !== cb) return ca - cb;
+    return a.name.localeCompare(b.name);
+  });
+}
+
 export function getInitials(name: string): string {
   const parts = name.trim().split(/\s+/);
   if (parts.length === 0 || parts[0] === "") return "";


### PR DESCRIPTION
## Summary
- **Sort crew members** by avatar color (PARTICIPANT_COLORS order) then alphabetically by name, across all views: crew page, rostrum timeline, and hub today snapshot
- **Fix basecamp save button** — the Maps URL `type="url"` input triggered browser validation that silently blocked form submission when the value wasn't a fully-qualified URL (e.g. missing `https://` prefix). Changed to `type="text"`

## Test plan
- [ ] Open Crew page — verify members are grouped by color, then alphabetical within each color
- [ ] Open Rostrum timeline — verify same sort order for participant rows
- [ ] Check Hub today snapshot arrivals/departures — verify sorted avatars
- [ ] Open Basecamp edit modal, enter a Maps URL without `https://`, click Save — verify it saves successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)