### PR TITLE
Remove user identity requirement from save actions

### DIFF
--- a/app/feasts/page.tsx
+++ b/app/feasts/page.tsx
@@ -5,7 +5,6 @@ import { Card } from "@/components/ui/Card";
 import { useTrip } from "@/lib/hooks/useTrip";
 import { useMeals } from "@/lib/hooks/useMeals";
 import { useParticipants } from "@/lib/hooks/useParticipants";
-import { useUser } from "@/components/providers/UserProvider";
 import { getDateRange, isToday } from "@/lib/utils/dates";
 import { DateScroller } from "@/components/feasts/DateScroller";
 import { DayMealCard } from "@/components/feasts/DayMealCard";
@@ -19,8 +18,6 @@ export default function FeastsPage() {
   const { trip, loading: tripLoading } = useTrip();
   const { meals, loading: mealsLoading } = useMeals();
   const { participants, loading: participantsLoading } = useParticipants();
-  const { user } = useUser();
-
   const dates = useMemo(
     () => (trip ? getDateRange(trip.startDate, trip.endDate) : []),
     [trip],
@@ -72,7 +69,7 @@ export default function FeastsPage() {
           date={resolvedDate}
           meal={currentMeal}
           participants={participants}
-          currentUserId={user?.id ?? ""}
+          currentUserId=""
         />
       )}
     </div>

--- a/components/basecamp/EditBasecampModal.tsx
+++ b/components/basecamp/EditBasecampModal.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 import { Modal } from "@/components/ui/Modal";
 import { Button } from "@/components/ui/Button";
-import { useUser } from "@/components/providers/UserProvider";
 import { updateBasecamp } from "@/lib/actions/basecamp";
 import type { Basecamp } from "@/lib/types";
 
@@ -77,7 +76,6 @@ export function EditBasecampModal({
   onClose: () => void;
   basecamp: Basecamp | null;
 }) {
-  const { user } = useUser();
   const [form, setForm] = useState<FormState>(() => basecampToForm(basecamp));
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -145,8 +143,6 @@ export function EditBasecampModal({
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!user) return;
-
     setSaving(true);
     setError(null);
     try {
@@ -165,7 +161,7 @@ export function EditBasecampModal({
           ),
           notes: form.notes,
         },
-        user.name,
+        "anonymous",
       );
       onClose();
     } catch (err) {

--- a/components/feasts/ClaimModal.tsx
+++ b/components/feasts/ClaimModal.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import { Modal } from "@/components/ui/Modal";
 import { Button } from "@/components/ui/Button";
 import { DietaryTag } from "@/components/ui/DietaryTag";
-import { useUser } from "@/components/providers/UserProvider";
 import { claimApero, claimDinner } from "@/lib/actions/meals";
 
 const DIETARY_PRESETS = [
@@ -30,7 +29,6 @@ export function ClaimModal({
   section: "apero" | "dinner";
   date: string;
 }) {
-  const { user } = useUser();
   const [notes, setNotes] = useState("");
   const [menu, setMenu] = useState("");
   const [dietaryTags, setDietaryTags] = useState<string[]>([]);
@@ -50,16 +48,14 @@ export function ClaimModal({
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!user) return;
-
     setSaving(true);
     try {
       if (section === "apero") {
-        await claimApero(date, { id: user.id, name: user.name }, notes.trim());
+        await claimApero(date, { id: "", name: "anonymous" }, notes.trim());
       } else {
         await claimDinner(
           date,
-          { id: user.id, name: user.name },
+          { id: "", name: "anonymous" },
           menu.trim(),
           dietaryTags,
         );


### PR DESCRIPTION
## Summary
- Basecamp save and meal claim actions were silently failing because they required a local user identity (`useUser`) that was never set up
- Removed the `useUser` dependency and `if (!user) return` guards from `EditBasecampModal`, `ClaimModal`, and `feasts/page.tsx`
- Uses `"anonymous"` for `updatedBy` fields since the app is trust-based with no auth

## Test plan
- [ ] Open basecamp, click edit, fill in any field, click Save — should persist
- [ ] Open feasts, claim an apero or dinner — should persist
- [ ] Verify no console errors on save

🤖 Generated with [Claude Code](https://claude.com/claude-code)