### PR TITLE
Add capacity indicator to lineup timeline

### DIFF
--- a/app/lineup/page.tsx
+++ b/app/lineup/page.tsx
@@ -5,14 +5,16 @@ import { Card } from "@/components/ui/Card";
 import { useTrip } from "@/lib/hooks/useTrip";
 import { useParticipants } from "@/lib/hooks/useParticipants";
 import { useAttendance } from "@/lib/hooks/useAttendance";
+import { useBasecamp } from "@/lib/hooks/useBasecamp";
 import { TimelineMatrix } from "@/components/lineup/TimelineMatrix";
 
 export default function LineupPage() {
   const { trip, loading: tripLoading } = useTrip();
   const { participants, loading: participantsLoading } = useParticipants();
   const { attendance, loading: attendanceLoading } = useAttendance();
+  const { basecamp, loading: basecampLoading } = useBasecamp();
 
-  const loading = tripLoading || participantsLoading || attendanceLoading;
+  const loading = tripLoading || participantsLoading || attendanceLoading || basecampLoading;
 
   if (loading) {
     return (
@@ -61,6 +63,7 @@ export default function LineupPage() {
           trip={trip}
           participants={participants}
           attendance={attendance}
+          capacity={basecamp?.capacity ?? null}
         />
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- Adds a capacity row at the bottom of the lineup timeline showing daily attendee counts
- Counts are color-coded based on chalet capacity: green (at/under), amber (>10% over), red (>20% over)
- Capacity data is fetched from the basecamp document via `useBasecamp()` hook

## Test plan
- [ ] Set a chalet capacity in Basecamp settings
- [ ] Navigate to Lineup page and verify the capacity row appears below participant rows
- [ ] Confirm counts are green when at or below capacity
- [ ] Confirm counts turn amber when 10%+ over capacity
- [ ] Confirm counts turn red when 20%+ over capacity
- [ ] Verify the row is hidden when no capacity is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)