### PR TITLE
Add alpine glassmorphism design

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Five main routes: `/` (hub dashboard), `/lineup` (attendance timeline), `/feasts
 
 ### Tailwind v4
 
-Uses `@import "tailwindcss"` in `globals.css` with CSS custom properties mapped via `@theme inline`. Design tokens: `bg-powder` (page bg), `bg-glacier` (card surfaces), `text-midnight` (primary text), `bg-alpine`/`text-alpine` (primary actions), `bg-spritz`/`text-spritz` (accent), `text-mist` (secondary text), `bg-pine`/`text-pine` (success).
+Uses `@import "tailwindcss"` in `globals.css` with CSS custom properties mapped via `@theme inline`. Design tokens: `text-midnight` (primary text), `bg-alpine`/`text-alpine` (primary actions), `bg-spritz`/`text-spritz` (accent), `text-mist` (secondary text), `bg-pine`/`text-pine` (success). Glassmorphism surface tokens: `bg-glass` (semi-transparent white, 70% opacity) for cards/modals/nav, `border-glass-border` (subtle white border). Body uses a fixed mountain-sky gradient; `AppShell` adds a gradient overlay div. Use `backdrop-blur-md` on glass surfaces. Form inputs use `bg-white/50` instead of the old `bg-powder`.
 
 ### Path Alias
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -8,6 +8,8 @@
   --spritz-orange: #F97316;
   --pine-green: #10B981;
   --mist-grey: #94A3B8;
+  --glass-bg: rgba(255, 255, 255, 0.70);
+  --glass-border: rgba(255, 255, 255, 0.20);
 }
 
 @theme inline {
@@ -18,9 +20,13 @@
   --color-spritz: var(--spritz-orange);
   --color-pine: var(--pine-green);
   --color-mist: var(--mist-grey);
+  --color-glass: var(--glass-bg);
+  --color-glass-border: var(--glass-border);
 }
 
 body {
-  background: var(--powder-white);
+  background: linear-gradient(135deg, #87CEEB 0%, #a8d8ea 30%, #E0E7EE 60%, #F8FAFC 100%);
   color: var(--midnight-slate);
+  min-height: 100vh;
+  background-attachment: fixed;
 }

--- a/components/UserSetupModal.tsx
+++ b/components/UserSetupModal.tsx
@@ -39,7 +39,7 @@ export function UserSetupModal({
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="Enter your name"
-            className="w-full rounded-xl border border-mist/30 bg-powder px-4 py-2.5 text-midnight placeholder:text-mist focus:outline-none focus:ring-2 focus:ring-alpine/50"
+            className="w-full rounded-xl border border-mist/30 bg-white/50 px-4 py-2.5 text-midnight placeholder:text-mist focus:outline-none focus:ring-2 focus:ring-alpine/50"
             autoFocus
           />
         </div>

--- a/components/basecamp/EditBasecampModal.tsx
+++ b/components/basecamp/EditBasecampModal.tsx
@@ -68,7 +68,7 @@ function parseCoordinates(
 }
 
 const inputClass =
-  "w-full rounded-xl border border-mist/30 bg-powder px-4 py-2.5 text-midnight placeholder:text-mist focus:outline-none focus:ring-2 focus:ring-alpine/50";
+  "w-full rounded-xl border border-mist/30 bg-white/50 px-4 py-2.5 text-midnight placeholder:text-mist focus:outline-none focus:ring-2 focus:ring-alpine/50";
 
 export function EditBasecampModal({
   isOpen,
@@ -314,7 +314,7 @@ export function EditBasecampModal({
           </legend>
           <div className="space-y-3">
             {form.emergencyContacts.map((contact, i) => (
-              <div key={i} className="space-y-2 rounded-xl bg-powder/50 p-3">
+              <div key={i} className="space-y-2 rounded-xl bg-white/30 p-3">
                 <input
                   type="text"
                   value={contact.name}

--- a/components/basecamp/EditTripModal.tsx
+++ b/components/basecamp/EditTripModal.tsx
@@ -8,7 +8,7 @@ import { seedMeals } from "@/lib/actions/meals";
 import type { Trip } from "@/lib/types";
 
 const inputClass =
-  "w-full rounded-xl border border-mist/30 bg-powder px-4 py-2.5 text-midnight placeholder:text-mist focus:outline-none focus:ring-2 focus:ring-alpine/50";
+  "w-full rounded-xl border border-mist/30 bg-white/50 px-4 py-2.5 text-midnight placeholder:text-mist focus:outline-none focus:ring-2 focus:ring-alpine/50";
 
 export function EditTripModal({
   isOpen,

--- a/components/crew/AddCrewModal.tsx
+++ b/components/crew/AddCrewModal.tsx
@@ -64,7 +64,7 @@ export function AddCrewModal({
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="Enter their name"
-            className="w-full rounded-xl border border-mist/30 bg-powder px-4 py-2.5 text-midnight placeholder:text-mist focus:outline-none focus:ring-2 focus:ring-alpine/50"
+            className="w-full rounded-xl border border-mist/30 bg-white/50 px-4 py-2.5 text-midnight placeholder:text-mist focus:outline-none focus:ring-2 focus:ring-alpine/50"
             autoFocus
           />
         </div>

--- a/components/crew/EditCrewModal.tsx
+++ b/components/crew/EditCrewModal.tsx
@@ -69,7 +69,7 @@ export function EditCrewModal({
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="Enter their name"
-            className="w-full rounded-xl border border-mist/30 bg-powder px-4 py-2.5 text-midnight placeholder:text-mist focus:outline-none focus:ring-2 focus:ring-alpine/50"
+            className="w-full rounded-xl border border-mist/30 bg-white/50 px-4 py-2.5 text-midnight placeholder:text-mist focus:outline-none focus:ring-2 focus:ring-alpine/50"
             autoFocus
           />
         </div>

--- a/components/feasts/DateScroller.tsx
+++ b/components/feasts/DateScroller.tsx
@@ -40,8 +40,8 @@ export function DateScroller({
               selected
                 ? "bg-alpine text-white"
                 : today
-                  ? "border border-alpine text-alpine bg-glacier"
-                  : "bg-glacier border border-mist/30 text-midnight",
+                  ? "border border-alpine text-alpine bg-glass backdrop-blur-sm"
+                  : "bg-glass backdrop-blur-sm border border-glass-border text-midnight",
             )}
           >
             {formatDateShort(date)}

--- a/components/feasts/EditDinnerModal.tsx
+++ b/components/feasts/EditDinnerModal.tsx
@@ -8,7 +8,7 @@ import { updateDinner } from "@/lib/actions/meals";
 import type { Meal, Participant } from "@/lib/types";
 
 const inputClass =
-  "w-full rounded-xl border border-mist/30 bg-powder px-4 py-2.5 text-midnight placeholder:text-mist focus:outline-none focus:ring-2 focus:ring-alpine/50";
+  "w-full rounded-xl border border-mist/30 bg-white/50 px-4 py-2.5 text-midnight placeholder:text-mist focus:outline-none focus:ring-2 focus:ring-alpine/50";
 
 export function EditDinnerModal({
   isOpen,

--- a/components/feasts/ParticipantPicker.tsx
+++ b/components/feasts/ParticipantPicker.tsx
@@ -29,7 +29,7 @@ export function ParticipantPicker({
               "flex items-center gap-2 rounded-full px-3 py-1.5 text-sm font-medium transition-colors border",
               selected
                 ? "border-alpine bg-alpine/10 text-alpine"
-                : "border-mist/30 bg-powder text-midnight hover:border-alpine/50",
+                : "border-mist/30 bg-white/50 text-midnight hover:border-alpine/50",
             )}
           >
             <Avatar

--- a/components/feasts/ShoppingList.tsx
+++ b/components/feasts/ShoppingList.tsx
@@ -109,7 +109,7 @@ export function ShoppingList({
           value={newItem}
           onChange={(e) => setNewItem(e.target.value)}
           placeholder="Add item..."
-          className="flex-1 rounded-lg border border-mist/30 bg-powder px-3 py-2 text-sm text-midnight placeholder:text-mist focus:outline-none focus:ring-2 focus:ring-alpine/50"
+          className="flex-1 rounded-lg border border-mist/30 bg-white/50 px-3 py-2 text-sm text-midnight placeholder:text-mist focus:outline-none focus:ring-2 focus:ring-alpine/50"
         />
         <button
           type="submit"

--- a/components/hub/DayCard.tsx
+++ b/components/hub/DayCard.tsx
@@ -69,7 +69,7 @@ export function DayCard({
         <button
           type="button"
           onClick={() => setEditOpen(true)}
-          className="w-full flex items-center justify-between gap-2 rounded-lg px-3 py-2 -mx-3 hover:bg-powder transition-colors text-left"
+          className="w-full flex items-center justify-between gap-2 rounded-lg px-3 py-2 -mx-3 hover:bg-white/40 transition-colors text-left"
         >
           <div className="min-w-0 flex-1">
             {responsibleNames.length > 0 ? (

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -7,6 +7,7 @@ import { OfflineBanner } from "@/components/layout/OfflineBanner";
 export function AppShell({ children }: { children: React.ReactNode }) {
   return (
     <>
+      <div className="fixed inset-0 -z-10 bg-gradient-to-br from-sky-300/40 via-sky-200/20 to-transparent" />
       <DesktopHeader />
       <OfflineBanner />
       <main className="min-h-screen pb-20 md:pb-0">

--- a/components/layout/DesktopHeader.tsx
+++ b/components/layout/DesktopHeader.tsx
@@ -20,7 +20,7 @@ export function DesktopHeader() {
   }
 
   return (
-    <header className="hidden md:block sticky top-0 z-40 bg-glacier/80 backdrop-blur-sm border-b border-mist/20">
+    <header className="hidden md:block sticky top-0 z-40 bg-glass backdrop-blur-md border-b border-glass-border">
       <div className="max-w-5xl mx-auto px-6 h-16 flex items-center justify-between">
         <Link href="/" className="flex items-center gap-2 text-lg font-bold text-midnight">
           <Image src="/logo.png" alt="" width={32} height={32} className="rounded-md" />

--- a/components/layout/MobileTabBar.tsx
+++ b/components/layout/MobileTabBar.tsx
@@ -48,7 +48,7 @@ export function MobileTabBar() {
   }
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 z-40 bg-glacier/95 backdrop-blur-sm border-t border-mist/20 md:hidden pb-[env(safe-area-inset-bottom)]">
+    <nav className="fixed bottom-0 left-0 right-0 z-40 bg-glass backdrop-blur-md border-t border-glass-border md:hidden pb-[env(safe-area-inset-bottom)]">
       <div className="flex items-center justify-around h-16">
         {tabs.map((tab) => (
           <Link

--- a/components/layout/OfflineBanner.tsx
+++ b/components/layout/OfflineBanner.tsx
@@ -8,7 +8,7 @@ export function OfflineBanner() {
   if (online) return null;
 
   return (
-    <div className="bg-spritz/10 text-spritz text-sm text-center py-2 px-4">
+    <div className="bg-spritz/10 text-spritz text-sm text-center py-2 px-4 backdrop-blur-md border-b border-spritz/10">
       You&apos;re offline — changes will sync when you reconnect
     </div>
   );

--- a/components/lineup/TimelineCell.tsx
+++ b/components/lineup/TimelineCell.tsx
@@ -20,7 +20,7 @@ export function TimelineCell({
       className={cn(
         "w-12 h-12 rounded-lg border-2 transition-colors shrink-0",
         !isPresent && isToday && "bg-alpine/5 border-alpine/20",
-        !isPresent && !isToday && "bg-powder border-mist/20",
+        !isPresent && !isToday && "bg-white/40 border-mist/20",
       )}
       style={isPresent ? { backgroundColor: participantColor, borderColor: participantColor } : undefined}
     />

--- a/components/lineup/TimelineRow.tsx
+++ b/components/lineup/TimelineRow.tsx
@@ -21,7 +21,7 @@ export function TimelineRow({
 }) {
   return (
     <div className="flex items-center gap-2">
-      <div className="w-32 shrink-0 sticky left-0 bg-glacier z-10 flex items-center gap-2 pr-2">
+      <div className="w-32 shrink-0 sticky left-0 bg-white/85 z-10 flex items-center gap-2 pr-2">
         <Avatar initials={participant.avatar} color={participant.color} size="sm" />
         <span className="text-sm font-medium text-midnight truncate flex-1">
           {participant.name}

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -10,7 +10,7 @@ export function Card({
   className?: string;
 }) {
   return (
-    <div className={cn("bg-glacier rounded-2xl shadow-sm p-5", className)}>
+    <div className={cn("bg-glass backdrop-blur-md border border-glass-border rounded-2xl shadow-lg p-5", className)}>
       {children}
     </div>
   );

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -30,7 +30,7 @@ export function Modal({
   return (
     <div className="fixed inset-0 z-50 flex items-end md:items-center justify-center">
       <div
-        className="absolute inset-0 bg-midnight/50"
+        className="absolute inset-0 bg-midnight/60 backdrop-blur-sm"
         onClick={onClose}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") onClose?.();
@@ -41,7 +41,7 @@ export function Modal({
       />
       <div
         className={cn(
-          "relative z-10 w-full bg-glacier",
+          "relative z-10 w-full bg-glass backdrop-blur-md border border-glass-border shadow-xl",
           "rounded-t-2xl md:rounded-2xl",
           "max-h-[90vh] overflow-y-auto",
           "md:max-w-md md:mx-4",


### PR DESCRIPTION
## Summary
- Replace flat white surfaces (`bg-powder`/`bg-glacier`) with frosted glass panels (`bg-glass backdrop-blur-md`) over a fixed mountain-sky gradient background
- Add `--glass-bg` and `--glass-border` CSS variables + Tailwind theme tokens for consistent glass treatment across Card, Modal, DesktopHeader, MobileTabBar, and OfflineBanner
- Update form inputs from `bg-powder` to `bg-white/50` and secondary surfaces (timeline cells, date scroller pills, sticky columns) to translucent white variants
- Update CLAUDE.md to document the new glassmorphism design tokens and conventions

## Test plan
- [ ] `npm run build` passes (verified)
- [ ] Visual check on all 5 routes (Hub, Crew, Basecamp, Lineup, Feasts)
- [ ] Cards show frosted glass over gradient background
- [ ] Nav bars (desktop header + mobile tab bar) blend with background
- [ ] Modals have glass panels with blurred backdrop
- [ ] Text is readable everywhere (especially `text-mist` secondary text)
- [ ] Mobile tab bar has glass treatment, no performance issues with blur

🤖 Generated with [Claude Code](https://claude.com/claude-code)