### PR TITLE
Add weather widget for La Tzoumaz to hub page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,10 @@ Firestore ←→ lib/hooks/use*.ts (onSnapshot listeners) → Components
 - Composite doc IDs: attendance uses `{participantId}_{YYYY-MM-DD}`, meals use `YYYY-MM-DD`.
 - Firestore rules are open read/write (no auth).
 
+### Weather
+
+Weather data for La Tzoumaz is fetched from the [Open-Meteo API](https://open-meteo.com/) (free, no API key). Data is cached in Firestore at `weather/la-tzoumaz` with a 1-hour TTL. `useWeather` hook listens via `onSnapshot` and triggers `refreshWeather()` action when stale. Utility functions in `lib/utils/weather.ts` map WMO codes to emoji/labels and provide snow vibe text.
+
 ### User Identity
 
 `UserProvider` uses `useSyncExternalStore` to read from localStorage key `apres-ski-user`. On first visit, `UserSetupModal` prompts for name/color. `saveUser()` writes to both localStorage and Firestore participants collection.

--- a/app/globals.css
+++ b/app/globals.css
@@ -30,3 +30,11 @@ body {
   min-height: 100vh;
   background-attachment: fixed;
 }
+
+@keyframes pulse-glow {
+  0%, 100% { box-shadow: 0 0 15px rgba(37, 99, 235, 0.2); }
+  50% { box-shadow: 0 0 25px rgba(37, 99, 235, 0.45); }
+}
+.animate-glow {
+  animation: pulse-glow 3s ease-in-out infinite;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { useMemo, useRef, useEffect, useState } from "react";
 import { Card } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
 import { LiteHero } from "@/components/hub/LiteHero";
+import { WeatherWidget } from "@/components/hub/WeatherWidget";
 import { DayCard } from "@/components/hub/DayCard";
 import { EditTripModal } from "@/components/basecamp/EditTripModal";
 import { useTrip } from "@/lib/hooks/useTrip";
@@ -11,7 +12,7 @@ import { useParticipants } from "@/lib/hooks/useParticipants";
 import { useAttendance } from "@/lib/hooks/useAttendance";
 import { useMeals } from "@/lib/hooks/useMeals";
 import { useBasecamp } from "@/lib/hooks/useBasecamp";
-import { getCountdownText, getTodayString } from "@/lib/utils/countdown";
+import { getTodayString } from "@/lib/utils/countdown";
 import { getDateRange } from "@/lib/utils/dates";
 import type { Meal } from "@/lib/types";
 
@@ -29,11 +30,6 @@ export default function HubPage() {
     attendanceLoading ||
     mealsLoading ||
     basecampLoading;
-
-  const countdownText = useMemo(() => {
-    if (!trip) return null;
-    return getCountdownText(trip.startDate, trip.endDate);
-  }, [trip]);
 
   const today = useMemo(() => getTodayString(), []);
 
@@ -74,7 +70,16 @@ export default function HubPage() {
   if (loading) {
     return (
       <div className="space-y-4">
-        <div className="h-8 w-48 rounded-lg bg-mist/20 animate-pulse" />
+        <div className="grid grid-cols-1 sm:grid-cols-[1fr_auto] gap-4 items-start">
+          <div className="h-8 w-48 rounded-lg bg-mist/20 animate-pulse" />
+          <Card className="animate-pulse min-w-[220px]">
+            <div className="space-y-3">
+              <div className="h-4 w-24 rounded bg-mist/20" />
+              <div className="h-8 w-16 rounded bg-mist/20" />
+              <div className="h-3 w-32 rounded bg-mist/20" />
+            </div>
+          </Card>
+        </div>
         <Card className="animate-pulse h-48">
           <span />
         </Card>
@@ -87,10 +92,14 @@ export default function HubPage() {
 
   return (
     <div className="space-y-4">
-      <LiteHero
-        tripName={trip?.name ?? null}
-        countdownText={countdownText}
-      />
+      <div className="grid grid-cols-1 sm:grid-cols-[1fr_auto] gap-4 items-start">
+        <LiteHero
+          tripName={trip?.name ?? null}
+          startDate={trip?.startDate ?? null}
+          endDate={trip?.endDate ?? null}
+        />
+        <WeatherWidget />
+      </div>
       {!trip ? (
         <>
           <Card>

--- a/components/hub/LiteHero.tsx
+++ b/components/hub/LiteHero.tsx
@@ -1,19 +1,86 @@
 "use client";
 
+import { useState, useEffect } from "react";
+import { getCountdownData, type CountdownData } from "@/lib/utils/countdown";
+
+function CountdownBlock({ value, label }: { value: number; label: string }) {
+  return (
+    <div className="flex flex-col items-center">
+      <div className="bg-spritz text-white text-5xl font-black px-5 py-3 rounded-lg shadow-lg min-w-[5rem] text-center tabular-nums">
+        {String(value).padStart(2, "0")}
+      </div>
+      <span className="text-xs font-bold text-white/80 mt-2 uppercase tracking-wider">
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function CountdownSeparator() {
+  return (
+    <div className="text-4xl font-black text-white/60 self-start pt-3">:</div>
+  );
+}
+
 export function LiteHero({
   tripName,
-  countdownText,
+  startDate,
+  endDate,
 }: {
   tripName: string | null;
-  countdownText: string | null;
+  startDate: string | null;
+  endDate: string | null;
 }) {
+  const [data, setData] = useState<CountdownData | null>(() =>
+    startDate && endDate ? getCountdownData(startDate, endDate) : null,
+  );
+
+  useEffect(() => {
+    if (!startDate || !endDate) return;
+    const id = setInterval(() => {
+      setData(getCountdownData(startDate, endDate));
+    }, 60_000);
+    return () => clearInterval(id);
+  }, [startDate, endDate]);
+
   return (
-    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1">
-      <h1 className="text-xl font-bold text-midnight">
+    <div className="flex flex-col items-center gap-3 py-2">
+      <h1 className="text-xl font-bold text-white drop-shadow-sm">
         {tripName ?? "Apres-Ski"}
       </h1>
-      {countdownText && (
-        <p className="text-sm text-mist">{countdownText}</p>
+
+      {data?.state === "before" && (
+        <>
+          <span className="uppercase tracking-widest text-xs font-black text-white/70">
+            Launching In
+          </span>
+          <div className="flex items-start gap-3">
+            <CountdownBlock value={data.days} label="Days" />
+            <CountdownSeparator />
+            <CountdownBlock value={data.hours} label="Hrs" />
+          </div>
+        </>
+      )}
+
+      {data?.state === "during" && (
+        <>
+          <span className="uppercase tracking-widest text-xs font-black text-white/70">
+            On The Mountain
+          </span>
+          <div className="flex items-start gap-3">
+            <CountdownBlock value={data.dayNum} label="Day" />
+            <div className="text-4xl font-black text-white/60 self-start pt-3">
+              /
+            </div>
+            <CountdownBlock value={data.totalDays} label="Total" />
+          </div>
+        </>
+      )}
+
+      {data?.state === "after" && (
+        <p className="text-sm font-semibold text-white/80">
+          Hope you had fun!
+        </p>
       )}
     </div>
   );

--- a/components/hub/WeatherWidget.tsx
+++ b/components/hub/WeatherWidget.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { Card } from "@/components/ui/Card";
+import { useWeather } from "@/lib/hooks/useWeather";
+import { getWeatherCondition, getSnowVibe } from "@/lib/utils/weather";
+import { cn } from "@/lib/utils/cn";
+
+export function WeatherWidget() {
+  const { data, loading, error } = useWeather();
+
+  if (loading) {
+    return (
+      <Card className="animate-pulse min-w-[220px]">
+        <div className="space-y-3">
+          <div className="h-4 w-24 rounded bg-mist/20" />
+          <div className="h-8 w-16 rounded bg-mist/20" />
+          <div className="h-3 w-32 rounded bg-mist/20" />
+        </div>
+      </Card>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <Card className="min-w-[220px]">
+        <p className="text-sm text-mist">Weather unavailable</p>
+      </Card>
+    );
+  }
+
+  const condition = getWeatherCondition(data.weatherCode);
+  const snowVibe = getSnowVibe(data.snowDepth);
+  const hasSnow = data.snowDepth > 10;
+
+  return (
+    <Card
+      className={cn(
+        "min-w-[220px]",
+        hasSnow && "ring-2 ring-alpine/50 animate-glow",
+      )}
+    >
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <span className="text-lg">
+            {condition.emoji} {condition.label}
+          </span>
+          <span className="text-xs text-mist">La Tzoumaz</span>
+        </div>
+
+        <div className="grid grid-cols-3 gap-3 text-center">
+          <div>
+            <p className="text-2xl font-bold text-alpine">{data.snowDepth}cm</p>
+            <p className="text-[11px] text-mist">Snow depth</p>
+          </div>
+          <div>
+            <p className="text-lg font-semibold text-midnight">
+              {Math.round(data.temperature)}°
+            </p>
+            <p className="text-[11px] text-mist">
+              {Math.round(data.temperatureMin)}° / {Math.round(data.temperatureMax)}°
+            </p>
+          </div>
+          <div>
+            <p className="text-lg font-semibold text-midnight">
+              {data.freezingLevel}m
+            </p>
+            <p className="text-[11px] text-mist">0° level</p>
+          </div>
+        </div>
+
+        <p className="text-xs text-mist text-center">{snowVibe}</p>
+      </div>
+    </Card>
+  );
+}

--- a/lib/actions/weather.ts
+++ b/lib/actions/weather.ts
@@ -1,0 +1,45 @@
+import { doc, setDoc, serverTimestamp } from "firebase/firestore";
+import { getDb } from "@/lib/firebase";
+
+export async function refreshWeather() {
+  const url =
+    "https://api.open-meteo.com/v1/forecast?" +
+    "latitude=46.08&longitude=7.23" +
+    "&current=temperature_2m,weather_code,snow_depth" +
+    "&daily=temperature_2m_max,temperature_2m_min" +
+    "&hourly=freezing_level_height" +
+    "&forecast_days=1" +
+    "&timezone=Europe/Zurich";
+
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Open-Meteo request failed: ${res.status}`);
+
+  const json = await res.json();
+
+  const temperature = json.current.temperature_2m as number;
+  const weatherCode = json.current.weather_code as number;
+  const snowDepthM = json.current.snow_depth as number;
+  const temperatureMin = json.daily.temperature_2m_min[0] as number;
+  const temperatureMax = json.daily.temperature_2m_max[0] as number;
+
+  const freezingLevels = json.hourly.freezing_level_height as number[];
+  const freezingLevel = Math.round(
+    freezingLevels.reduce((a: number, b: number) => a + b, 0) /
+      freezingLevels.length,
+  );
+
+  const db = getDb();
+  await setDoc(
+    doc(db, "weather", "la-tzoumaz"),
+    {
+      temperature,
+      temperatureMin,
+      temperatureMax,
+      weatherCode,
+      snowDepth: Math.round(snowDepthM * 100),
+      freezingLevel,
+      fetchedAt: serverTimestamp(),
+    },
+    { merge: true },
+  );
+}

--- a/lib/hooks/useWeather.ts
+++ b/lib/hooks/useWeather.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { doc, onSnapshot } from "firebase/firestore";
+import { getDb } from "@/lib/firebase";
+import { refreshWeather } from "@/lib/actions/weather";
+import type { WeatherData } from "@/lib/types";
+
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+export function useWeather() {
+  const [data, setData] = useState<WeatherData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const refreshing = useRef(false);
+
+  useEffect(() => {
+    const db = getDb();
+    const unsub = onSnapshot(
+      doc(db, "weather", "la-tzoumaz"),
+      (snap) => {
+        const weather = snap.exists() ? (snap.data() as WeatherData) : null;
+        setData(weather);
+        setLoading(false);
+
+        const fetchedAt = weather?.fetchedAt?.toMillis?.() ?? 0;
+        const isStale = Date.now() - fetchedAt > ONE_HOUR_MS;
+
+        if (isStale && !refreshing.current) {
+          refreshing.current = true;
+          refreshWeather()
+            .catch((err) => setError(err))
+            .finally(() => {
+              refreshing.current = false;
+            });
+        }
+      },
+      (err) => {
+        setError(err);
+        setLoading(false);
+      },
+    );
+
+    return unsub;
+  }, []);
+
+  return { data, loading, error };
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -59,6 +59,16 @@ export interface Basecamp {
   updatedBy: string;
 }
 
+export interface WeatherData {
+  temperature: number;
+  temperatureMin: number;
+  temperatureMax: number;
+  weatherCode: number;
+  snowDepth: number;
+  freezingLevel: number;
+  fetchedAt: Timestamp;
+}
+
 export interface LocalUser {
   id: string;
   name: string;

--- a/lib/utils/countdown.ts
+++ b/lib/utils/countdown.ts
@@ -32,3 +32,36 @@ export function getCountdownText(startDate: string, endDate: string): string {
     ) + 1;
   return `Day ${dayNum} of ${totalDays}`;
 }
+
+export type CountdownData =
+  | { state: "before"; days: number; hours: number }
+  | { state: "during"; dayNum: number; totalDays: number }
+  | { state: "after" };
+
+export function getCountdownData(startDate: string, endDate: string): CountdownData {
+  const now = new Date();
+  const start = new Date(`${startDate}T00:00:00`);
+  const end = new Date(`${endDate}T23:59:59`);
+
+  if (now < start) {
+    const diffMs = start.getTime() - now.getTime();
+    const days = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+    const hours = Math.floor((diffMs % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+    return { state: "before", days, hours };
+  }
+
+  if (now > end) {
+    return { state: "after" };
+  }
+
+  const todayStart = new Date(`${getTodayString()}T00:00:00`);
+  const dayNum =
+    Math.floor(
+      (todayStart.getTime() - start.getTime()) / (1000 * 60 * 60 * 24),
+    ) + 1;
+  const totalDays =
+    Math.floor(
+      (new Date(`${endDate}T00:00:00`).getTime() - start.getTime()) / (1000 * 60 * 60 * 24),
+    ) + 1;
+  return { state: "during", dayNum, totalDays };
+}

--- a/lib/utils/weather.ts
+++ b/lib/utils/weather.ts
@@ -1,0 +1,46 @@
+const WMO_CODES: Record<number, { emoji: string; label: string }> = {
+  0: { emoji: "☀️", label: "Clear sky" },
+  1: { emoji: "🌤️", label: "Mostly clear" },
+  2: { emoji: "⛅", label: "Partly cloudy" },
+  3: { emoji: "☁️", label: "Overcast" },
+  45: { emoji: "🌫️", label: "Foggy" },
+  48: { emoji: "🌫️", label: "Icy fog" },
+  51: { emoji: "🌧️", label: "Light drizzle" },
+  53: { emoji: "🌧️", label: "Drizzle" },
+  55: { emoji: "🌧️", label: "Heavy drizzle" },
+  56: { emoji: "🌧️", label: "Freezing drizzle" },
+  57: { emoji: "🌧️", label: "Heavy freezing drizzle" },
+  61: { emoji: "🌧️", label: "Light rain" },
+  63: { emoji: "🌧️", label: "Rain" },
+  65: { emoji: "🌧️", label: "Heavy rain" },
+  66: { emoji: "🧊", label: "Freezing rain" },
+  67: { emoji: "🧊", label: "Heavy freezing rain" },
+  71: { emoji: "🌨️", label: "Light snow" },
+  73: { emoji: "❄️", label: "Snow" },
+  75: { emoji: "❄️", label: "Heavy snow" },
+  77: { emoji: "🌨️", label: "Snow grains" },
+  80: { emoji: "🌦️", label: "Light showers" },
+  81: { emoji: "🌦️", label: "Showers" },
+  82: { emoji: "🌦️", label: "Heavy showers" },
+  85: { emoji: "🌨️", label: "Light snow showers" },
+  86: { emoji: "❄️", label: "Heavy snow showers" },
+  95: { emoji: "⛈️", label: "Thunderstorm" },
+  96: { emoji: "⛈️", label: "Thunderstorm with hail" },
+  99: { emoji: "⛈️", label: "Thunderstorm with heavy hail" },
+};
+
+export function getWeatherCondition(code: number): {
+  emoji: string;
+  label: string;
+} {
+  return WMO_CODES[code] ?? { emoji: "❓", label: "Unknown" };
+}
+
+export function getSnowVibe(snowDepthCm: number): string {
+  if (snowDepthCm >= 100) return "Powder paradise!";
+  if (snowDepthCm >= 50) return "Deep and dreamy";
+  if (snowDepthCm >= 30) return "Solid base";
+  if (snowDepthCm >= 10) return "Decent cover";
+  if (snowDepthCm > 0) return "Thin cover";
+  return "No snow yet";
+}


### PR DESCRIPTION
## Summary
- **Weather widget** on the hub page fetches live conditions for La Tzoumaz from Open-Meteo API (free, no key needed)
- Data cached in Firestore (`weather/la-tzoumaz`) with 1-hour TTL — all clients share the cache via `onSnapshot`
- Shows snow depth, current temperature (min/max), freezing level, and WMO-coded weather condition with emoji
- Glassmorphism card with **alpine glow animation** when snow depth exceeds 10cm
- **Enhanced countdown**: LiteHero now shows visual countdown blocks (days/hours) before the trip and day/total progress during it
- `getCountdownData()` utility for structured countdown state

## New files
| File | Purpose |
|------|---------|
| `lib/utils/weather.ts` | WMO code → emoji/label mapping, snow vibe text |
| `lib/actions/weather.ts` | `refreshWeather()` — fetches Open-Meteo, writes to Firestore |
| `lib/hooks/useWeather.ts` | `onSnapshot` listener + staleness check triggers refresh |
| `components/hub/WeatherWidget.tsx` | Glassmorphism card with snow/temp/freezing metrics |

## Test plan
- [ ] `npm run build` passes with no type errors
- [ ] `npm run lint` passes with no errors
- [ ] Hub page shows weather widget top-right (desktop) or stacked (mobile)
- [ ] Widget displays loading skeleton, then weather data
- [ ] Glow animation appears when snow depth > 10cm
- [ ] Countdown blocks show before trip starts, day progress during trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)